### PR TITLE
Export Instruments: change back to original dir at end

### DIFF
--- a/sf2_loader/read_sf2/read_sf2.py
+++ b/sf2_loader/read_sf2/read_sf2.py
@@ -1142,6 +1142,7 @@ current preset name: {self.get_current_instrument()}'''
                            name=None,
                            show_full_path=False,
                            export_args={}):
+        original_dir = os.getcwd()
         try:
             os.mkdir(folder_name)
             os.chdir(folder_name)
@@ -1185,6 +1186,7 @@ current preset name: {self.get_current_instrument()}'''
                              name=current_name,
                              export_args=export_args)
         print('exporting finished')
+        os.chdir(original_dir)
         self.change(current_channel, current_sfid, current_bank,
                     current_preset)
 

--- a/sf2_loader/read_sf2/read_sf2.py
+++ b/sf2_loader/read_sf2/read_sf2.py
@@ -1145,7 +1145,7 @@ current preset name: {self.get_current_instrument()}'''
         try:
             os.mkdir(folder_name)
             os.chdir(folder_name)
-        except:
+        except FileExistsError:
             os.chdir(folder_name)
         current_channel = copy(self.current_channel)
         current_sfid = copy(self.current_sfid)

--- a/sf2_loader/read_sf2_32bit/read_sf2.py
+++ b/sf2_loader/read_sf2_32bit/read_sf2.py
@@ -1146,7 +1146,7 @@ current preset name: {self.get_current_instrument()}'''
         try:
             os.mkdir(folder_name)
             os.chdir(folder_name)
-        except:
+        except FileExistsError:
             os.chdir(folder_name)
         current_channel = copy(self.current_channel)
         current_sfid = copy(self.current_sfid)

--- a/sf2_loader/read_sf2_32bit/read_sf2.py
+++ b/sf2_loader/read_sf2_32bit/read_sf2.py
@@ -1143,6 +1143,7 @@ current preset name: {self.get_current_instrument()}'''
                            name=None,
                            show_full_path=False,
                            export_args={}):
+        original_dir = os.getcwd()
         try:
             os.mkdir(folder_name)
             os.chdir(folder_name)
@@ -1186,6 +1187,7 @@ current preset name: {self.get_current_instrument()}'''
                              name=current_name,
                              export_args=export_args)
         print('exporting finished')
+        os.chdir(original_dir)
         self.change(current_channel, current_sfid, current_bank,
                     current_preset)
 


### PR DESCRIPTION
Currently `export_instruments` will create a new dir, cd to it, then export, but will not go back to the original dir afterwards. If running this function multiple times, this can create a set of messy, nested directories. This changes back to the original dir when exporting is finished. 

Also introduces more specific handling of `FileExistsError` when attempting to create the new directory, rather than blindly catching all errors. 